### PR TITLE
Revert merging models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ before_install: gem install xcpretty cocoapods obcd slather -N
 podfile: Podfile
 script: xcodebuild -workspace Demo.xcworkspace -scheme Tests -sdk iphonesimulator build test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test | xcpretty -c && exit ${PIPESTATUS[0]}
 after_success: slather
+notifications:
+  email: false

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		146E61941C89903200BDAC73 /* DataModelTest.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 146E61931C89903200BDAC73 /* DataModelTest.xcdatamodel */; };
 		148C33481BD7CB18009701BF /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 148C33461BD7CB18009701BF /* Model.xcdatamodeld */; };
 		148C33511BD7CB67009701BF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 148C33501BD7CB67009701BF /* main.m */; };
 		148C33541BD7CB67009701BF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 148C33531BD7CB67009701BF /* AppDelegate.m */; };
@@ -28,6 +29,7 @@
 /* Begin PBXFileReference section */
 		146D72AC1AB782920058798C /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146D72B11AB782920058798C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		146E61931C89903200BDAC73 /* DataModelTest.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DataModelTest.xcdatamodel; sourceTree = "<group>"; };
 		148C33471BD7CB18009701BF /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		148C334D1BD7CB67009701BF /* DemoObjectiveC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoObjectiveC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		148C33501BD7CB67009701BF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 		146D72AF1AB782920058798C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				146E61931C89903200BDAC73 /* DataModelTest.xcdatamodel */,
 				148C33461BD7CB18009701BF /* Model.xcdatamodeld */,
 				14A139B31AEFC72B00AD732F /* Tests.swift */,
 				146D72B01AB782920058798C /* Supporting Files */,
@@ -472,6 +475,7 @@
 			files = (
 				14A139B41AEFC72B00AD732F /* Tests.swift in Sources */,
 				148C33481BD7CB18009701BF /* Model.xcdatamodeld in Sources */,
+				146E61941C89903200BDAC73 /* DataModelTest.xcdatamodel in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -60,10 +60,21 @@ import TestCheck
             if _persistentStoreCoordinator == nil {
                 let filePath = (self.storeName ?? self.modelName) + ".sqlite"
 
-                guard let modelURL = self.modelBundle.URLForResource(self.modelName, withExtension: "momd"), model = NSManagedObjectModel(contentsOfURL: modelURL)
-                    else { fatalError("Model with model name \(self.modelName) not found in bundle \(self.modelBundle)") }
+                var model: NSManagedObjectModel?
 
-                let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+                if let momdModelURL = self.modelBundle.URLForResource(self.modelName, withExtension: "momd") {
+                    model = NSManagedObjectModel(contentsOfURL: momdModelURL)
+                }
+
+                if let momModelURL = self.modelBundle.URLForResource(self.modelName, withExtension: "mom") {
+                    model = NSManagedObjectModel(contentsOfURL: momModelURL)
+                }
+
+                if model == nil {
+                    fatalError("Model with model name \(self.modelName) not found in bundle \(self.modelBundle)")
+                }
+
+                let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model!)
 
                 switch self.storeType {
                 case .InMemory:

--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -28,7 +28,7 @@ import TestCheck
                 context.undoManager = nil
                 context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
                 context.parentContext = self.writerContext
-                
+
                 _mainContext = context
             }
 
@@ -58,8 +58,10 @@ import TestCheck
     private var persistentStoreCoordinator: NSPersistentStoreCoordinator {
         get {
             if _persistentStoreCoordinator == nil {
-                guard let model = NSManagedObjectModel.mergedModelFromBundles([self.modelBundle])
-                    else { fatalError("No model found in bundle \(self.modelBundle)") }
+                let filePath = (self.storeName ?? self.modelName) + ".sqlite"
+
+                guard let modelURL = self.modelBundle.URLForResource(self.modelName, withExtension: "momd"), model = NSManagedObjectModel(contentsOfURL: modelURL)
+                    else { fatalError("Model with model name \(self.modelName) not found in bundle \(self.modelBundle)") }
 
                 let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
 
@@ -73,7 +75,6 @@ import TestCheck
 
                     break
                 case .SQLite:
-                    let filePath = (self.storeName ?? self.modelName) + ".sqlite"
                     let storeURL = self.applicationDocumentsDirectory().URLByAppendingPathComponent(filePath)
                     guard let storePath = storeURL.path else { fatalError("Store path not found: \(storeURL)") }
 
@@ -116,10 +117,10 @@ import TestCheck
                             fatalError("Excluding SQLite file from backup caused an error: \(excludingError)")
                         }
                     }
-                    
+
                     break
                 }
-                
+
                 _persistentStoreCoordinator = persistentStoreCoordinator
             }
 
@@ -138,8 +139,8 @@ import TestCheck
     }
 
     private lazy var disposablePersistentStoreCoordinator: NSPersistentStoreCoordinator = {
-        guard let model = NSManagedObjectModel.mergedModelFromBundles([self.modelBundle])
-            else { fatalError("No model found in bundle \(self.modelBundle)") }
+        guard let modelURL = self.modelBundle.URLForResource(self.modelName, withExtension: "momd"), model = NSManagedObjectModel(contentsOfURL: modelURL)
+            else { fatalError("Model named \(self.modelName) not found in bundle \(self.modelBundle)") }
 
         let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
         do {
@@ -147,7 +148,7 @@ import TestCheck
         } catch let error as NSError {
             fatalError("There was an error creating the disposablePersistentStoreCoordinator: \(error)")
         }
-        
+
         return persistentStoreCoordinator
     }()
 

--- a/Tests/DataModelTest.xcdatamodel/contents
+++ b/Tests/DataModelTest.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15D21" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/Tests/DataModelTest.xcdatamodel/contents
+++ b/Tests/DataModelTest.xcdatamodel/contents
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15D21" minimumToolsVersion="Xcode 7.0">
-    <elements/>
+    <entity name="User" syncable="YES">
+        <attribute name="createdDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="User" positionX="-63" positionY="-18" width="128" height="90"/>
+    </elements>
 </model>

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -110,4 +110,9 @@ class Tests: XCTestCase {
         let objects = self.fetchObjectsInContext(dataStack.mainContext)
         XCTAssertEqual(objects.count, 0)
     }
+
+    func testAlternativeModel() {
+        let dataStack = DATAStack(modelName: "DataModelTest", bundle: NSBundle(forClass: Tests.self), storeType: .SQLite)
+        XCTAssertNotNil(dataStack)
+    }
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -113,6 +113,7 @@ class Tests: XCTestCase {
 
     func testAlternativeModel() {
         let dataStack = DATAStack(modelName: "DataModelTest", bundle: NSBundle(forClass: Tests.self), storeType: .SQLite)
+        self.insertUserInContext(dataStack.mainContext)
         XCTAssertNotNil(dataStack)
     }
 }


### PR DESCRIPTION
#34 added support for using `mom` files, before only `momd` files were accepted. #34 fixed this in a way that cause performance issues in other projects. This PR adds the same functionality without the decrease in performance.