### PR TITLE
fix Xcode 7.3 TestCheck

### DIFF
--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -323,7 +323,7 @@ struct TestCheck {
         let enviroment = NSProcessInfo.processInfo().environment
         let serviceName = enviroment["XPC_SERVICE_NAME"]
         let injectBundle = enviroment["XCInjectBundle"]
-        var isRunning = (enviroment["TRAVIS"] != nil)
+        var isRunning = (enviroment["TRAVIS"] != nil || enviroment["XCTestConfigurationFilePath"] != nil)
 
         if !isRunning {
             if let serviceName = serviceName {


### PR DESCRIPTION
Xcode 7.3 breaks the TestCheck.
The last comment in this thread fix it (http://stackoverflow.com/questions/24688512/what-is-the-proper-way-to-detect-if-unit-tests-are-running-at-runtime-in-xcode)