### PR TITLE
newMainContext() method (issue #74)

### DIFF
--- a/DATAStack.podspec
+++ b/DATAStack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "DATAStack"
-  s.version = "5.4.0"
+  s.version = "5.4.1"
   s.summary = "100% Swift Simple Boilerplate Free Core Data Stack"
   s.description = <<-DESC
                    * Easier thread safety

--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -127,7 +127,7 @@ import CoreData
      Initializes a DATAStack using the provided model name, bundle and storeType.
      - parameter modelName: The name of your Core Data model (xcdatamodeld).
      - parameter bundle: The bundle where your Core Data model is located, normally your Core Data model is in
-     the main bundle but saveMainThreadwhen using unit tests sometimes your Core Data model could be located where your tests
+     the main bundle but when using unit tests sometimes your Core Data model could be located where your tests
      are located.
      - parameter storeType: The store type to be used, you have .InMemory and .SQLite, the first one is memory
      based and doesn't save to disk, while the second one creates a .sqlite file and stores things there.


### PR DESCRIPTION
I’ve made new method, that is helpful in UI operations when user can discard own changes, backgroundContext is not solution here.

I had posted an issue #74 before, but I don’t like proposed solution Core Data →  JSON → Core Data conversion to simply save or discard data, I don’t think that is the best way to do such task.

I ask to check code, because I’ve copy-pasted some code and I don’t know full tests structure (I’ve done tests, but I don’t know if they are working properly). Maybe I have some fatal error at my method.