### PR TITLE
Log if backgroundContext was created in main thread

### DIFF
--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -208,7 +208,7 @@ import CoreData
      example when using a NSFetchedResultsController use `try self.fetchedResultsController.performFetch()`.
      */
     public func newNonMergingBackgroundContext() -> NSManagedObjectContext {
-		logIfMainContext()
+		logIfMainThread()
 		
         let context = NSManagedObjectContext(concurrencyType: DATAStack.backgroundConcurrencyType())
         context.persistentStoreCoordinator = self.persistentStoreCoordinator
@@ -222,7 +222,7 @@ import CoreData
      Returns a background context perfect for data mutability operations. Make sure to never use it on the main thread. Use `performBlock` or `performBlockAndWait` to use it.
      */
     public func newBackgroundContext() -> NSManagedObjectContext {
-		logIfMainContext()
+		logIfMainThread()
 		
         let context = NSManagedObjectContext(concurrencyType: DATAStack.backgroundConcurrencyType())
         context.persistentStoreCoordinator = self.persistentStoreCoordinator
@@ -364,7 +364,7 @@ import CoreData
         return TestCheck.isTesting ? NSSelectorFromString("performBlockAndWait:") : NSSelectorFromString("performBlock:")
     }
 	
-	private func logIfMainContext() {
+	private func logIfMainThread() {
 		if NSThread.isMainThread() {
 			NSLog("[DATAStack] You've created background context in main thread, that may cause unexpected behaviour and crashes.")
 		}

--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -208,6 +208,8 @@ import CoreData
      example when using a NSFetchedResultsController use `try self.fetchedResultsController.performFetch()`.
      */
     public func newNonMergingBackgroundContext() -> NSManagedObjectContext {
+		logIfMainContext()
+		
         let context = NSManagedObjectContext(concurrencyType: DATAStack.backgroundConcurrencyType())
         context.persistentStoreCoordinator = self.persistentStoreCoordinator
         context.undoManager = nil
@@ -220,6 +222,8 @@ import CoreData
      Returns a background context perfect for data mutability operations. Make sure to never use it on the main thread. Use `performBlock` or `performBlockAndWait` to use it.
      */
     public func newBackgroundContext() -> NSManagedObjectContext {
+		logIfMainContext()
+		
         let context = NSManagedObjectContext(concurrencyType: DATAStack.backgroundConcurrencyType())
         context.persistentStoreCoordinator = self.persistentStoreCoordinator
         context.undoManager = nil
@@ -359,6 +363,12 @@ import CoreData
     private static func performSelectorForBackgroundContext() -> Selector {
         return TestCheck.isTesting ? NSSelectorFromString("performBlockAndWait:") : NSSelectorFromString("performBlock:")
     }
+	
+	private func logIfMainContext() {
+		if NSThread.isMainThread() {
+			NSLog("[DATAStack] You've created background context in main thread, that may cause unexpected behaviour and crashes.")
+		}
+	}
 }
 
 extension NSPersistentStoreCoordinator {


### PR DESCRIPTION
Little addition to help developer to catch Core Data crashes if backgroundContext was created in incorrect thread. Very often Core Data in that cases shows in NSLog something non-human readable if you you’re accidentally forget about threads.