### PR TITLE
 Added possibility to exclude sqlite stores from backup

### DIFF
--- a/Source/DATAStack.swift
+++ b/Source/DATAStack.swift
@@ -29,7 +29,7 @@ import CoreData
 
     private let backgroundContextName = "DATAStack.backgroundContextName"
     
-    private var isExcludedFromBackup = true
+    private var isExcludedFromBackup = false
 
     /**
      The context for the main queue. Please do not use this to mutate data, use `performInNewBackgroundContext`
@@ -95,8 +95,9 @@ import CoreData
     /**
      Initializes a DATAStack using the provided model name.
      - parameter modelName: The name of your Core Data model (xcdatamodeld).
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Default set to false.
      */
-    @objc public init(modelName: String, isExcludedFromBackup: Bool = true) {
+    @objc public init(modelName: String, isExcludedFromBackup: Bool = false) {
         self.modelName = modelName
         self.isExcludedFromBackup = isExcludedFromBackup
         self.model = NSManagedObjectModel(bundle: self.modelBundle, name: self.modelName)
@@ -109,8 +110,9 @@ import CoreData
      - parameter modelName: The name of your Core Data model (xcdatamodeld).
      - parameter storeType: The store type to be used, you have .InMemory and .SQLite, the first one is memory
      based and doesn't save to disk, while the second one creates a .sqlite file and stores things there.
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Only applies to sqlite stores. Default set to false.
      */
-    @objc public init(modelName: String, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = true) {
+    @objc public init(modelName: String, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = false) {
         self.modelName = modelName
         self.storeType = storeType
         self.isExcludedFromBackup = isExcludedFromBackup
@@ -127,8 +129,9 @@ import CoreData
      are located.
      - parameter storeType: The store type to be used, you have .InMemory and .SQLite, the first one is memory
      based and doesn't save to disk, while the second one creates a .sqlite file and stores things there.
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Only applies to sqlite stores. Default set to false.
      */
-    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = true) {
+    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = false) {
         self.modelName = modelName
         self.modelBundle = bundle
         self.storeType = storeType
@@ -149,8 +152,9 @@ import CoreData
      - parameter storeName: Normally your file would be named as your model name is named, so if your model
      name is AwesomeApp then the .sqlite file will be named AwesomeApp.sqlite, this attribute allows your to
      change that.
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Only applies to sqlite stores. Default set to false.
      */
-    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, storeName: String, isExcludedFromBackup: Bool = true) {
+    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, storeName: String, isExcludedFromBackup: Bool = false) {
         self.modelName = modelName
         self.modelBundle = bundle
         self.storeType = storeType
@@ -173,8 +177,9 @@ import CoreData
      name is AwesomeApp then the .sqlite file will be named AwesomeApp.sqlite, this attribute allows your to
      change that.
      - parameter containerURL: The container URL for the sqlite file when a store type of SQLite is used.
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Only applies to sqlite stores. Default set to false.
      */
-    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, storeName: String, containerURL: URL, isExcludedFromBackup: Bool = true) {
+    @objc public init(modelName: String, bundle: Bundle, storeType: DATAStackStoreType, storeName: String, containerURL: URL, isExcludedFromBackup: Bool = false) {
         self.modelName = modelName
         self.modelBundle = bundle
         self.storeType = storeType
@@ -191,8 +196,9 @@ import CoreData
      - parameter model: The model that we'll use to set up your DATAStack.
      - parameter storeType: The store type to be used, you have .InMemory and .SQLite, the first one is memory
      based and doesn't save to disk, while the second one creates a .sqlite file and stores things there.
+     - parameter isExcludedFromBackup: Flag to indicate if the data store should be excluded from backup. Only applies to sqlite stores. Default set to false
      */
-    @objc public init(model: NSManagedObjectModel, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = true) {
+    @objc public init(model: NSManagedObjectModel, storeType: DATAStackStoreType, isExcludedFromBackup: Bool = false) {
         self.model = model
         self.storeType = storeType
         self.isExcludedFromBackup = isExcludedFromBackup


### PR DESCRIPTION
Before, sqlite stores were automatically excluded from iCloud backups. Now the default behavior is to included them in backups, but it's also possible to explicit exclude a store from the backups when you initialize the data stack. 